### PR TITLE
Add Twitter feedback dashboard

### DIFF
--- a/app/api/twitter/feedback/route.js
+++ b/app/api/twitter/feedback/route.js
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '../../../../libs/supabase/server.js';
+import { withAuthAPI } from '../../../../libs/auth-utils.js';
+
+async function handler(request) {
+  const user = request.user;
+  const supabase = createClient();
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const sortBy = searchParams.get('sortBy') || 'created_at';
+    const ascending = searchParams.get('ascending') === 'true';
+
+    console.log(`Fetching Twitter feedback for user ${user.id}, sorting by ${sortBy}`);
+
+    const { data: feedback, error } = await supabase
+      .from('raw_feedback')
+      .select('*')
+      .eq('user_id', user.id)
+      .eq('platform', 'twitter')
+      .order(sortBy, { ascending });
+
+    if (error) {
+      console.error('Error fetching Twitter feedback:', error);
+      throw error;
+    }
+
+    return NextResponse.json({ success: true, data: feedback || [] });
+  } catch (error) {
+    console.error('[API Twitter Feedback Error]', error);
+    return NextResponse.json(
+      { success: false, error: 'Failed to fetch Twitter feedback', message: error.message },
+      { status: 500 }
+    );
+  }
+}
+
+export const GET = withAuthAPI(handler);

--- a/app/dashboard/twitter/page.js
+++ b/app/dashboard/twitter/page.js
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { createClient } from "../../../libs/supabase/client.js";
+import { useRouter } from "next/navigation";
+import TwitterDashboard from "../../../components/TwitterDashboard.js";
+
+export default function TwitterPage() {
+  const supabase = createClient();
+  const router = useRouter();
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const getUser = async () => {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user) {
+        router.push("/signin");
+        return;
+      }
+
+      setUser(user);
+      setLoading(false);
+    };
+
+    getUser();
+  }, [router, supabase]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-center">
+          <div className="loading loading-spinner loading-lg"></div>
+          <p className="mt-4 text-base-content/70">Loading Twitter Dashboard...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 lg:pl-8">
+      <div className="max-w-7xl mx-auto">
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-8">
+          <div>
+            <h1 className="text-3xl md:text-4xl font-bold">Twitter Feedback</h1>
+            <p className="text-base-content/70 mt-2">
+              View and manage tweets synced from your Twitter integration.
+            </p>
+          </div>
+        </div>
+        
+        <TwitterDashboard user={user} />
+      </div>
+    </div>
+  );
+}

--- a/components/DashboardNav.js
+++ b/components/DashboardNav.js
@@ -25,6 +25,12 @@ export default function DashboardNav() {
       description: "Add and manage feedback",
     },
     {
+      name: "Twitter",
+      href: "/dashboard/twitter",
+      icon: "🐦",
+      description: "View synced tweets",
+    },
+    {
       name: "Analytics",
       href: "/dashboard/analytics",
       icon: "📊",

--- a/components/TweetCard.js
+++ b/components/TweetCard.js
@@ -1,0 +1,40 @@
+import React from 'react';
+
+const TweetCard = ({ tweet }) => {
+  const { content, metadata, created_at } = tweet;
+
+  const author = metadata?.author || 'unknown';
+  const authorId = metadata?.author_id || '';
+  const followers = metadata?.followers || 0;
+  const likes = metadata?.likes || 0;
+  const retweets = metadata?.retweets || 0;
+  const tweetUrl = `https://twitter.com/${author}/status/${tweet.source_id}`;
+
+  return (
+    <div className="card bg-base-200 shadow-md hover:shadow-xl transition-shadow duration-200">
+      <div className="card-body">
+        <div className="flex items-start justify-between">
+          <div>
+            <a href={`https://twitter.com/${author}`} target="_blank" rel="noopener noreferrer" className="font-bold link link-hover">
+              @{author}
+            </a>
+            <p className="text-xs text-base-content/70">{followers.toLocaleString()} followers</p>
+          </div>
+          <a href={tweetUrl} target="_blank" rel="noopener noreferrer" className="text-xs link link-hover">
+            {new Date(created_at).toLocaleDateString()}
+          </a>
+        </div>
+        <p className="my-4 text-base-content/90">{content}</p>
+        <div className="card-actions justify-end items-center">
+          <div className="flex items-center gap-4 text-sm">
+            <span>❤️ {likes}</span>
+            <span>🔁 {retweets}</span>
+          </div>
+          <button className="btn btn-sm btn-primary">Create Feedback</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TweetCard;

--- a/components/TwitterDashboard.js
+++ b/components/TwitterDashboard.js
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState, useEffect, useCallback } from 'react';
+import toast from 'react-hot-toast';
+import TweetCard from './TweetCard.js';
+
+const TwitterDashboard = ({ user }) => {
+  const [tweets, setTweets] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [syncing, setSyncing] = useState(false);
+  const [error, setError] = useState(null);
+  const [sortBy, setSortBy] = useState('created_at');
+  const [ascending, setAscending] = useState(false);
+
+  const fetchTweets = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/twitter/feedback?sortBy=${sortBy}&ascending=${ascending}`);
+      const data = await response.json();
+      if (!data.success) {
+        throw new Error(data.error || 'Failed to fetch tweets');
+      }
+      setTweets(data.data);
+    } catch (err) {
+      setError(err.message);
+      toast.error(`Error fetching tweets: ${err.message}`);
+    } finally {
+      setLoading(false);
+    }
+  }, [sortBy, ascending]);
+
+  useEffect(() => {
+    fetchTweets();
+  }, [fetchTweets]);
+
+  const handleSync = async () => {
+    setSyncing(true);
+    toast.loading('Syncing with Twitter...');
+    try {
+      const response = await fetch('/api/sync/twitter', { method: 'POST' });
+      const data = await response.json();
+      toast.dismiss();
+
+      if (!data.success) {
+        throw new Error(data.error || 'Sync failed');
+      }
+      toast.success(`Sync complete! Found ${data.processed} new tweets.`);
+      await fetchTweets();
+    } catch (err) {
+      toast.dismiss();
+      toast.error(`Sync failed: ${err.message}`);
+    } finally {
+      setSyncing(false);
+    }
+  };
+
+  const handleSortChange = (newSortBy) => {
+    if (newSortBy === sortBy) {
+      setAscending(!ascending);
+    } else {
+      setSortBy(newSortBy);
+      setAscending(false);
+    }
+  };
+  
+  if (loading) {
+    return (
+      <div className="text-center p-8">
+        <span className="loading loading-spinner loading-lg"></span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="alert alert-error">
+        <span>{error}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col md:flex-row justify-between items-center gap-4 p-4 bg-base-200 rounded-lg">
+        <div className="flex items-center gap-2">
+            <span className="font-semibold">Sort by:</span>
+            <button className={`btn btn-sm ${sortBy === 'created_at' ? 'btn-active' : ''}`} onClick={() => handleSortChange('created_at')}>Date</button>
+            <button className={`btn btn-sm ${sortBy === 'metadata->>likes' ? 'btn-active' : ''}`} onClick={() => handleSortChange('metadata->>likes')}>Likes</button>
+            <button className={`btn btn-sm ${sortBy === 'metadata->>followers' ? 'btn-active' : ''}`} onClick={() => handleSortChange('metadata->>followers')}>Followers</button>
+        </div>
+        <button className={`btn btn-primary ${syncing ? 'loading' : ''}`} onClick={handleSync} disabled={syncing}>
+          {syncing ? 'Syncing...' : 'Sync Now'}
+        </button>
+      </div>
+
+      {tweets.length === 0 ? (
+        <div className="text-center p-12 bg-base-200 rounded-lg">
+          <h3 className="text-xl font-semibold">No tweets found</h3>
+          <p className="text-base-content/70 mt-2">Try syncing with Twitter or check your keywords in the Integrations settings.</p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {tweets.map((tweet) => (
+            <TweetCard key={tweet.id} tweet={tweet} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TwitterDashboard;


### PR DESCRIPTION
## Summary
- implement `/api/twitter/feedback` endpoint
- add a new Twitter dashboard page with loading/auth handling
- create `TweetCard` and `TwitterDashboard` components
- update sidebar navigation with link to Twitter dashboard

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_687b6d933564832cb47430d7bbbf962b